### PR TITLE
Sending key inputs requires less get requests

### DIFF
--- a/Current/CamerasHazmatQR/main.py
+++ b/Current/CamerasHazmatQR/main.py
@@ -94,7 +94,9 @@ STATE_SERVER_MASTER = {
     "gpu": -1,
     "angle": 0,
 }
-STATE_SERVER = {} # keys
+STATE_SERVER = {
+    "keys": [],
+}
 # ---------------------------------------------------------------------------- #
 
 
@@ -103,15 +105,14 @@ def server_main(server_dq):
     app = Flask(__name__)
     server_ds = util.DoubleState(STATE_SERVER_MASTER, STATE_SERVER)
 
-
     @app.route("/")
     def index():
         return render_template("index.html")
 
-
-    @app.route("/set/<key>/<value>", methods=["GET"])
-    def set_key(key, value):
-        server_ds.s2[key] = value
+    @app.route("/keys/<keys_str>", methods=["GET"])
+    def keys(keys_str):
+        keys = keys_str.split("-")
+        server_ds.s2["keys"] = keys
 
         server_ds.put_s2(server_dq)
 
@@ -119,7 +120,6 @@ def server_main(server_dq):
         response.headers.add("Access-Control-Allow-Origin", "*")
 
         return response
-
 
     @app.route("/get", methods=["GET"])
     def get():
@@ -129,7 +129,6 @@ def server_main(server_dq):
         response.headers.add("Access-Control-Allow-Origin", "*")
 
         return response
-    
 
     app.run(debug=False, port=5000, host="0.0.0.0")
 # ---------------------------------------------------------------------------- #
@@ -281,7 +280,7 @@ def camera_main(camera_dq, key):
 
 # ---------------------------------------------------------------------------- #
 def key_down(keys, key):
-    return keys.get(key, "false") == "true"
+    return key in keys
     
 def fps_text(frame, fps):
     font = cv2.FONT_HERSHEY_SIMPLEX
@@ -446,33 +445,33 @@ def master_main(hazmat_dq, server_dq, camera_dqs, video_capture_zero, gpu_log_fi
         # -------------------------------------------------------------------- #
         server_ds.update_s2(server_dq)
 
-        if hazmat_tk.down(key_down(server_ds.s2, HAZMAT_TOGGLE_KEY)):
+        if hazmat_tk.down(key_down(server_ds.s2["keys"], HAZMAT_TOGGLE_KEY)):
             run_hazmat_toggler.toggle()
-        run_hazmat_hold = key_down(server_ds.s2, HAZMAT_HOLD_KEY)
+        run_hazmat_hold = key_down(server_ds.s2["keys"], HAZMAT_HOLD_KEY)
         
-        if qr_tk.down(key_down(server_ds.s2, QR_TOGGLE_KEY)):
+        if qr_tk.down(key_down(server_ds.s2["keys"], QR_TOGGLE_KEY)):
             run_qr_toggler.toggle()
-        if motion_tk.down(key_down(server_ds.s2, MOTION_TOGGLE_KEY)):
+        if motion_tk.down(key_down(server_ds.s2["keys"], MOTION_TOGGLE_KEY)):
             run_motion_toggler.toggle()
 
-        if key_down(server_ds.s2, QR_CLEAR_KEY):
+        if key_down(server_ds.s2["keys"], QR_CLEAR_KEY):
             all_qr_found = []
 
-        if key_down(server_ds.s2, HAZMAT_CLEAR_KEY):
+        if key_down(server_ds.s2["keys"], HAZMAT_CLEAR_KEY):
             hazmat_ds.s1["clear_all_found"] = 1
 
-        if key_down(server_ds.s2, "0"):
+        if key_down(server_ds.s2["keys"], "0"):
             view_mode.mode = util.ViewMode.GRID
-        elif key_down(server_ds.s2, "1"):
+        elif key_down(server_ds.s2["keys"], "1"):
             view_mode.mode = util.ViewMode.ZOOM
             view_mode.zoom_on = 0
-        elif key_down(server_ds.s2, "2"):
+        elif key_down(server_ds.s2["keys"], "2"):
             view_mode.mode = util.ViewMode.ZOOM
             view_mode.zoom_on = 1
-        elif key_down(server_ds.s2, "3"):
+        elif key_down(server_ds.s2["keys"], "3"):
             view_mode.mode = util.ViewMode.ZOOM
             view_mode.zoom_on = 2
-        elif key_down(server_ds.s2, "4"):
+        elif key_down(server_ds.s2["keys"], "4"):
             view_mode.mode = util.ViewMode.ZOOM
             view_mode.zoom_on = 3        
         # -------------------------------------------------------------------- #

--- a/Current/CamerasHazmatQR/main.py
+++ b/Current/CamerasHazmatQR/main.py
@@ -108,6 +108,17 @@ def server_main(server_dq):
     @app.route("/")
     def index():
         return render_template("index.html")
+    
+    @app.route("/keys/", methods=["GET"])
+    def no_keys_down():
+        server_ds.s2["keys"] = []
+
+        server_ds.put_s2(server_dq)
+
+        response = jsonify(server_ds.s2)
+        response.headers.add("Access-Control-Allow-Origin", "*")
+
+        return response
 
     @app.route("/keys/<keys_str>", methods=["GET"])
     def keys(keys_str):

--- a/Current/CamerasHazmatQR/templates/index.html
+++ b/Current/CamerasHazmatQR/templates/index.html
@@ -238,7 +238,7 @@ kbd {
 
 		const DELAY = 1000 / FRONT_END_FPS;
 
-		const STATE = {}; // STATE[key] = true/false
+		const keys = {}; // keys[key] = true | if key is down
 
 		let show_sidebar = true;
 
@@ -384,18 +384,21 @@ kbd {
 				});
 		}, DELAY);
 
-		function send_state() {
-			const base_path = "set";
-			for (const key in STATE) {
-				const path = base_path + "/" + key + "/" + STATE[key];
-				fetch(FLASK_SERVER + path);
-			}
-		}
 
+        function send_keys() {
+            const base_path = "keys";
+            const object_keys = Object.keys(keys);
+            const keys_str = object_keys.join("-");
+            const path = base_path + "/" + keys_str;
+            fetch(FLASK_SERVER + path);
+
+            const keys_ele = document.getElementById("keys");
+            keys_ele.innerHTML = object_keys.sort().join(", ");
+        }
 		function keydown(e) {
 			const key = e.key;
-			STATE[key] = true;
-			send_state();
+			keys[key] = true;
+            send_keys();
 
 			if (key == 5) {
 				show_sidebar = !show_sidebar;
@@ -405,8 +408,7 @@ kbd {
 		}
 		function keyup(e) {
 			const key = e.key;
-			STATE[key] = false;
-			send_state();
+            delete keys[key];
 		}
 
 		window.addEventListener("keydown", keydown);

--- a/Current/CamerasHazmatQR/templates/index.html
+++ b/Current/CamerasHazmatQR/templates/index.html
@@ -226,7 +226,7 @@ kbd {
 				Press <kbd>5</kbd> to toggle sidebar.<br />
 			</p>
 
-            <h5>Keys Down</h5>
+            <h4>Keys Down</h4>
             <p id="keys"></p>
 		</div>
 	</div>
@@ -385,6 +385,12 @@ kbd {
 		}, DELAY);
 
 
+		function display_keys() {
+            const object_keys = Object.keys(keys);
+			const keys_ele = document.getElementById("keys");
+            keys_ele.innerHTML = object_keys.sort().join(", ");
+		}
+
         function send_keys() {
             const base_path = "keys";
             const object_keys = Object.keys(keys);
@@ -392,11 +398,10 @@ kbd {
             const path = base_path + "/" + keys_str;
             fetch(FLASK_SERVER + path);
 
-            const keys_ele = document.getElementById("keys");
-            keys_ele.innerHTML = object_keys.sort().join(", ");
+			display_keys();
         }
 		function keydown(e) {
-			const key = e.key;
+			const key = e.key.toLowerCase();
 			keys[key] = true;
             send_keys();
 
@@ -409,6 +414,7 @@ kbd {
 		function keyup(e) {
 			const key = e.key;
             delete keys[key];
+            send_keys();
 		}
 
 		window.addEventListener("keydown", keydown);


### PR DESCRIPTION
All requests are combined as `/keys/a-b-c` instead of `/set/<key>/<value>` for every key